### PR TITLE
fix: Orientation lock not called when disabled

### DIFF
--- a/dist/ImageViewing.d.ts
+++ b/dist/ImageViewing.d.ts
@@ -27,6 +27,7 @@ declare type Props = {
     FooterComponent?: ComponentType<{
         imageIndex: number;
     }>;
+    disablePortraitLock?: boolean;
 };
 declare const EnhancedImageViewing: (props: Props) => JSX.Element;
 export default EnhancedImageViewing;

--- a/dist/ImageViewing.js
+++ b/dist/ImageViewing.js
@@ -17,7 +17,7 @@ import useRequestClose from "./hooks/useRequestClose";
 const DEFAULT_ANIMATION_TYPE = "fade";
 const DEFAULT_BG_COLOR = "#000";
 const DEFAULT_DELAY_LONG_PRESS = 800;
-function ImageViewing({ images, imageIndex, visible, onRequestClose, onLongPress = () => { }, onImageIndexChange, animationType = DEFAULT_ANIMATION_TYPE, backgroundColor = DEFAULT_BG_COLOR, presentationStyle, swipeToCloseEnabled, doubleTapToZoomEnabled, delayLongPress = DEFAULT_DELAY_LONG_PRESS, HeaderComponent, FooterComponent, }) {
+function ImageViewing({ images, imageIndex, visible, onRequestClose, onLongPress = () => { }, onImageIndexChange, animationType = DEFAULT_ANIMATION_TYPE, backgroundColor = DEFAULT_BG_COLOR, presentationStyle, swipeToCloseEnabled, doubleTapToZoomEnabled, delayLongPress = DEFAULT_DELAY_LONG_PRESS, HeaderComponent, FooterComponent, disablePortraitLock, }) {
     var _a;
     const imageList = React.createRef();
     const [opacity, onRequestCloseEnhanced] = useRequestClose(onRequestClose);
@@ -29,7 +29,9 @@ function ImageViewing({ images, imageIndex, visible, onRequestClose, onLongPress
             Orientation.unlockAllOrientations();
         }
         return () => {
-            Orientation.lockToPortrait();
+            if (!disablePortraitLock) {
+                Orientation.lockToPortrait();
+            }
         };
     }, [visible]);
     useEffect(() => {
@@ -47,7 +49,9 @@ function ImageViewing({ images, imageIndex, visible, onRequestClose, onLongPress
         return null;
     }
     const onRequestCloseWithLock = () => {
-        Orientation.lockToPortrait();
+        if (!disablePortraitLock) {
+            Orientation.lockToPortrait();
+        }
         onRequestCloseEnhanced();
     };
     return (<Modal transparent={presentationStyle === "overFullScreen"} visible={visible} presentationStyle={presentationStyle} animationType={animationType} onRequestClose={onRequestCloseWithLock} supportedOrientations={["portrait", "landscape"]} hardwareAccelerated>

--- a/dist/components/Text/Theme.d.ts
+++ b/dist/components/Text/Theme.d.ts
@@ -8,7 +8,6 @@ declare const theme: {
         surface: string;
         text: string;
         onSurface: string;
-        onBackground: string;
         disabled: string;
         placeholder: string;
         backdrop: string;
@@ -18,7 +17,7 @@ declare const theme: {
         primary: string;
     };
     fontFamily: string;
-    fonts: import("react-native-paper/lib/typescript/src/types").Fonts;
+    fonts: import("react-native-paper/lib/typescript/types").Fonts;
     dark: boolean;
     mode?: "adaptive" | "exact" | undefined;
     roundness: number;

--- a/src/ImageViewing.tsx
+++ b/src/ImageViewing.tsx
@@ -41,6 +41,7 @@ type Props = {
   delayLongPress?: number;
   HeaderComponent?: ComponentType<{ imageIndex: number }>;
   FooterComponent?: ComponentType<{ imageIndex: number }>;
+  disablePortraitLock?: boolean;
 };
 
 const DEFAULT_ANIMATION_TYPE = "fade";
@@ -62,6 +63,7 @@ function ImageViewing({
   delayLongPress = DEFAULT_DELAY_LONG_PRESS,
   HeaderComponent,
   FooterComponent,
+  disablePortraitLock,
 }: Props) {
   const imageList = React.createRef<VirtualizedList<ImageSource>>();
   const [opacity, onRequestCloseEnhanced] = useRequestClose(onRequestClose);
@@ -79,7 +81,9 @@ function ImageViewing({
       Orientation.unlockAllOrientations();
     }
     return () => {
-      Orientation.lockToPortrait();
+      if (!disablePortraitLock) {
+          Orientation.lockToPortrait();
+      }
     }
   }, [visible]);
 
@@ -103,7 +107,9 @@ function ImageViewing({
   }
 
   const onRequestCloseWithLock = () => {
-    Orientation.lockToPortrait();
+    if (!disablePortraitLock) {
+      Orientation.lockToPortrait();
+    }
     onRequestCloseEnhanced();
   }
 


### PR DESCRIPTION
Allow overriding of `Orientation.lockToPortrait();` call to be disabled.

Ticket: https://learntowin.atlassian.net/browse/L2WIN-4245